### PR TITLE
Documentation update: Remove querydsl-apt from regular classpath

### DIFF
--- a/querydsl-jpa/README.md
+++ b/querydsl-jpa/README.md
@@ -9,13 +9,6 @@ The JPA module provides integration with the JPA 2 persistence API.
 ```XML
 <dependency>
   <groupId>com.querydsl</groupId>
-  <artifactId>querydsl-apt</artifactId>
-  <version>${querydsl.version}</version>
-  <scope>provided</scope>
-</dependency>    
-    
-<dependency>
-  <groupId>com.querydsl</groupId>
   <artifactId>querydsl-jpa</artifactId>
   <version>${querydsl.version}</version>
 </dependency>
@@ -49,6 +42,13 @@ And now, configure the Maven APT plugin :
             </configuration>
           </execution>
         </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.querydsl</groupId>
+            <artifactId>querydsl-apt</artifactId>
+            <version>${querydsl.version}</version>
+          </dependency
+        </dependencies>
       </plugin>
       ...
     </plugins>


### PR DESCRIPTION
When a dependency is set to 'provided' the classes are available on classpath during development. Even worse: The compiler is compiling the code with success and the implementation will fail due runtime. 

The solution for that issue is (I think): Add the dependency to the maven plugin itself. So it's only available due runtime of the plugin and won't be added to the classpath of the programm itself.